### PR TITLE
Configure Pages build environment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3
+      - uses: actions/configure-pages@v5
       - name: Install dependencies
         run: bundle install --jobs 4 --retry 3
       - name: Build site


### PR DESCRIPTION
## Summary
- ensure GitHub Pages workflow configures the Pages environment before installing dependencies and building the site

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68bb1fb7ebe48329836333581d05435f