### PR TITLE
Populate portfolio with resume data and project hierarchy

### DIFF
--- a/_data/projects.json
+++ b/_data/projects.json
@@ -1,0 +1,22 @@
+{
+  "active": [
+    {
+      "title": "Unreal Gameplay Systems",
+      "slug": "ue-gameplay-systems",
+      "description": "Suite of reusable systems for UE5 including dialogue and quest modules.",
+      "tags": ["unreal", "cpp"],
+      "sub_projects": [
+        {"title": "Advanced Dialogue System", "slug": "ue-advanced-dialogue", "tags": ["unreal", "cpp"]},
+        {"title": "Questing & Behavior Systems", "slug": "ue-quest-behavior", "tags": ["unreal", "cpp"]}
+      ]
+    }
+  ],
+  "completed": [
+    {
+      "title": "Oday — YouTube Playlists Web App",
+      "slug": "oday-playlists",
+      "description": "Curates and surfaces multi-playlist learning tracks with a minimal, distraction-free UI.",
+      "tags": ["web", "angular"]
+    }
+  ]
+}

--- a/_data/resume.json
+++ b/_data/resume.json
@@ -1,0 +1,156 @@
+{
+    "name": "KEVIN 'TYLER' COX",
+    "position": "Unreal Engine 5 C++ Gameplay Systems Developer",
+    "contactInformation": "(843) 718-4024",
+    "email": "kevincox103@gmail.com",
+    "address": "Charleston, SC",
+    "profilePicture": "",
+    "socialMedia": [
+        { "socialMedia": "Github", "link": "github.com/Ty-lerCox" },
+        {
+            "socialMedia": "LinkedIn",
+            "link": "linkedin.com/in/tyler-cox-1715065a/"
+        },
+        { "socialMedia": "Website", "link": "https://ty-lercox.github.io/portfolio/" }
+    ],
+    "summary": "UE5/C++ systems developer building gameplay architecture with web-grade discipline: Redux-style state (actions/effects/state), dialogue and quest systems, AI & advanced spawning, cinematic HUD/UMG, and web-inspired UI. Integrated an in-game guide chatbot using language models with context caching to reduce cost and latency. Several years of UE5 experience; focused on data-driven design, maintainability, and iteration speed.",
+    "education": [
+        {
+            "school": "Trident Technical College",
+            "degree": "Computer Science",
+            "startYear": "",
+            "endYear": "2013-12-31"
+        }
+    ],
+    "workExperience": [
+        {
+            "company": "Independent / Self-Employed",
+            "position": "UE5/C++ Game Systems Developer",
+            "description": "Design and implementation of core gameplay systems and tools in Unreal Engine 5 with emphasis on maintainable, data-driven C++.",
+            "keyAchievements": "Built branching Dialogue System with multi-option choices and conditional availability based on quest state (current/completed/required).\nEngineered Quest System supporting multi-objective tasks, required counts, dependencies, and side effects (trigger cinematics, spawn NPCs, state changes).\nEstablished Redux-style architecture in C++ (actions, effects, state) to isolate subsystems and improve testability and maintainability.\nCreated AI movement and a needs model; authored advanced spawner logic for unpredictable NPC distribution with region rules, cooldowns, and variance.\nImplemented story-management and transition volumes to control floor/zone visibility and scene flow.\nDeveloped cinematic HUD widgets and web-inspired UI components to accelerate iteration and improve UX.\nDelivered inventory and shop subsystems integrated with global game state; built a codex/collection system to track collectibles and progression.\nIntegrated an in-game guide chatbot (LLM) with command interface; used context caching to reduce token usage and latency.\nPracticed data-driven configuration, profiling, and optimization across systems.",
+            "startYear": "2025-01-01",
+            "endYear": "Present"
+        },
+        {
+            "company": "Expediters International (Expediters)",
+            "position": "Angular Application Developer (Additional Professional Experience)",
+            "description": "Primary employer; application development, DevOps, and observability (transferable engineering practices).",
+            "keyAchievements": "Led state management patterns (NgRx, Angular Signals) and modular architecture across multiple internal applications.\nStood up observability with Grafana stack (Prometheus metrics, Loki logs, Tempo traces) and alerting; emphasized instrumentation and telemetry—skills applicable to game profiling and tooling.\nAutomated CI/CD with GitHub Actions/GitLab Runners and Ansible; supported Kubernetes deployments; improved iteration speed and reliability.\nImplemented SSO (Keycloak OIDC/SAML), Kerberos integrations, and PKI/CA for TLS/mTLS; enforced secure defaults.\nModernized data flows from bespoke Kafka producers to database-level CDC → Kafka with medallion layers (bronze/silver/gold).\nUsed Python for rapid prototypes; production services in Java Spring Boot and C#/.NET; practiced feature flags, DORA metrics, and Kanban for flow.",
+            "startYear": "2014-09-01",
+            "endYear": "Present"
+        }
+    ],
+    "projects": [
+        {
+            "title": "Dialogue System (UE5/C++)",
+            "link": "https://github.com/bedivere-lea",
+            "description": "Branching, conditional dialogue with quest-aware availability and consequence tracking.",
+            "keyAchievements": "Multi-option choices; gating by current/completed/required quests; integrates with Redux-style game state.",
+            "startYear": "2025-05-01",
+            "endYear": "2025-05-31",
+            "name": "Dialogue System (UE5/C++)"
+        },
+        {
+            "title": "Quest System (UE5/C++)",
+            "link": "https://github.com/bedivere-lea",
+            "description": "Objectives with counts, dependencies, and side effects wired to gameplay events.",
+            "keyAchievements": "Triggers cinematics; spawns NPCs; updates global state via actions/effects.",
+            "startYear": "2025-05-01",
+            "endYear": "2025-05-31",
+            "name": "Quest System (UE5/C++)"
+        },
+        {
+            "title": "AI Needs & Advanced Spawning",
+            "link": "https://github.com/bedivere-lea",
+            "description": "AI behavior model with needs (Sims-like) and region-based spawner rules.",
+            "keyAchievements": "Unpredictable spawn distribution; cooldowns and variance; tunable via data assets.",
+            "startYear": "2025-06-01",
+            "endYear": "2025-06-30",
+            "name": "AI Needs & Advanced Spawning"
+        },
+        {
+            "title": "Story/Level Flow Controls",
+            "link": "https://github.com/bedivere-lea",
+            "description": "Volume-based story transitions with floor/zone visibility controls.",
+            "keyAchievements": "Performance-aware visibility; clean narrative gating; improved player readability.",
+            "startYear": "2025-06-01",
+            "endYear": "2025-06-30",
+            "name": "Story/Level Flow Controls"
+        },
+        {
+            "title": "Inventory & Shop Subsystems",
+            "link": "https://github.com/bedivere-lea",
+            "description": "Item catalogs, purchasing, and persistence integrated with global game state.",
+            "keyAchievements": "Predictable side effects; data-driven tuning; testable modules.",
+            "startYear": "2025-07-01",
+            "endYear": "2025-07-31",
+            "name": "Inventory & Shop Subsystems"
+        },
+        {
+            "title": "Codex/Collection System",
+            "link": "https://github.com/bedivere-lea",
+            "description": "Collectible tracking and progression feedback loops.",
+            "keyAchievements": "Player progress surfaces; unlock conditions; consistent data schema.",
+            "startYear": "2025-07-01",
+            "endYear": "2025-07-31",
+            "name": "Codex/Collection System"
+        },
+        {
+            "title": "Guide Chatbot Integration (LLM)",
+            "link": "https://github.com/bedivere-lea",
+            "description": "In-game user-guide chat agent using language models.",
+            "keyAchievements": "Command interface; context caching to lower inference cost and latency; domain-specific prompt toolkit.",
+            "startYear": "2025-08-01",
+            "endYear": "2025-08-31",
+            "name": "Guide Chatbot Integration (LLM)"
+        },
+        {
+            "title": "Redux-Style Game State Library",
+            "link": "https://github.com/bedivere-lea",
+            "description": "Shared actions/effects/state managers used across gameplay subsystems.",
+            "keyAchievements": "Separation of concerns; maintainable C++ modules; easier testing and debugging.",
+            "startYear": "2025-08-01",
+            "endYear": "2025-08-31",
+            "name": "Redux-Style Game State Library"
+        }
+    ],
+    "skills": [
+        {
+            "title": "Technical Skills",
+            "skills": [
+                "Unreal Engine 5",
+                "C++ (Gameplay Framework, UObjects/Actors/Components)",
+                "UMG/HUD",
+                "Dialogue & Quest Systems",
+                "AI Movement & Spawning",
+                "Redux-style State (actions/effects/state)",
+                "Data-Driven Design",
+                "Tooling & Debugging",
+                "Profiling & Optimization",
+                "LLM Integration (context caching)",
+                "Git"
+            ]
+        },
+        {
+            "title": "Soft Skills",
+            "skills": [
+                "Systems Thinking",
+                "Problem Solving",
+                "Communication",
+                "Self-Direction",
+                "Iteration & Rapid Prototyping"
+            ]
+        },
+        {
+            "title": "Additional Skills",
+            "skills": [
+                "Cinematic UI/UX",
+                "Testability & Maintainability",
+                "Documentation",
+                "Kanban & Delivery Flow"
+            ]
+        }
+    ],
+    "languages": ["English"],
+    "certifications": []
+}

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -1,0 +1,20 @@
+---
+layout: default
+---
+
+<h1>Tag: {{ page.tag }}</h1>
+<ul>
+{% assign all = site.data.projects.active | concat: site.data.projects.completed %}
+{% for project in all %}
+  {% if project.tags contains page.tag %}
+    <li><a href="{{ '/projects/' | append: project.slug | append: '/' | relative_url }}">{{ project.title }}</a></li>
+  {% endif %}
+  {% if project.sub_projects %}
+    {% for sub in project.sub_projects %}
+      {% if sub.tags contains page.tag %}
+        <li><a href="{{ '/projects/' | append: sub.slug | append: '/' | relative_url }}">{{ sub.title }}</a></li>
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endfor %}
+</ul>

--- a/index.md
+++ b/index.md
@@ -1,14 +1,14 @@
 ---
-title: Portfolio — Your Name
+title: Portfolio — {{ site.data.resume.name }}
 layout: home
 image: /assets/img/social-card.svg
 ---
 
-# Your Name
-_Unreal Engine & Web Developer_  
+# {{ site.data.resume.name }}
+_{{ site.data.resume.position }}_
 Designing developer-friendly systems and shipping neat, usable tools.
 
-<img src="{{ '/assets/img/headshot.svg' | relative_url }}" alt="Your Name headshot" width="120" align="right">
+<img src="{{ '/assets/img/headshot.svg' | relative_url }}" alt="{{ site.data.resume.name }} headshot" width="120" align="right">
 
 <a href="#projects">View Projects</a> • <a href="{{ '/resume/resume.pdf' | relative_url }}">Download Resume (PDF)</a> • <a href="#contact">Contact</a>
 
@@ -23,32 +23,20 @@ Designing developer-friendly systems and shipping neat, usable tools.
 
 ## Featured Projects {#projects}
 
-### Advanced Dialogue System (UE)
-![Dialogue System Thumbnail]({{ '/assets/img/dialogue-thumb.svg' | relative_url }})
-Branching, conditional dialogue with data-driven nodes and editor tooling for authors.  
-**Tech:** UE5, C++, Data Assets, Editor Utility Widgets  
-**Role:** Systems design & implementation • **Outcome:** faster authoring, fewer runtime bugs  
-[Read the case study →]({{ '/projects/ue-advanced-dialogue/' | relative_url }})
+{% assign featured = site.data.projects.active | concat: site.data.projects.completed %}
+{% for project in featured %}
+### {{ project.title }}
+{{ project.description }}
+{% if project.sub_projects %}
+Sub-projects:
+{% for sub in project.sub_projects %}
+- [{{ sub.title }}]({{ '/projects/' | append: sub.slug | append: '/' | relative_url }})
+{% endfor %}
+{% endif %}
+[Read the case study →]({{ '/projects/' | append: project.slug | append: '/' | relative_url }})
 
 ---
-
-### Questing & Behavior Systems (UE)
-![Quest System Thumbnail]({{ '/assets/img/quest-thumb.svg' | relative_url }})
-Composable quests with Behavior Tree integrations and reusable task library.  
-**Tech:** UE5, C++, Behavior Trees, Blackboards  
-**Role:** Systems & tooling • **Outcome:** designers can compose new quests without code  
-[Read the case study →]({{ '/projects/ue-quest-behavior/' | relative_url }})
-
----
-
-### Oday — YouTube Playlists Web App
-![Oday Thumbnail]({{ '/assets/img/oday-thumb.svg' | relative_url }})
-Curates and surfaces multi-playlist learning tracks with clean, minimal UI.  
-**Tech:** JavaScript/TypeScript, HTML5, CSS, GitHub Pages (or your stack)  
-**Role:** Full‑stack & UX • **Outcome:** faster discovery and continuity across playlists  
-[Read the case study →]({{ '/projects/oday-playlists/' | relative_url }})
-
----
+{% endfor %}
 
 ## Skills (snapshot)
 **Languages:** C++, TypeScript/JavaScript  
@@ -73,6 +61,7 @@ See the full history on the [Resume]({{ '/resume/' | relative_url }}).
 ---
 
 ## Contact {#contact}
-**Email:** <a href="mailto:yourname@example.com">yourname@example.com</a> • **GitHub:** yourhandle • **LinkedIn:** /in/yourhandle
+**Email:** <a href="mailto:{{ site.data.resume.email }}">{{ site.data.resume.email }}</a>
+{% for profile in site.data.resume.socialMedia %}• **{{ profile.socialMedia }}:** <a href="{{ profile.link }}">{{ profile.link }}</a> {% endfor %}
 
 _Last updated: {{ site.time | date: "%B %Y" }}_

--- a/projects/index.md
+++ b/projects/index.md
@@ -7,9 +7,24 @@ layout: default
 
 A curated set of systems and apps. Each write-up is a quick read with code and outcomes.
 
-- **Advanced Dialogue System (UE)** — branching, conditional, data-driven.  
-  [Read →]({{ '/projects/ue-advanced-dialogue/' | relative_url }})
-- **Questing & Behavior Systems (UE)** — composable quests with BT integration.  
-  [Read →]({{ '/projects/ue-quest-behavior/' | relative_url }})
-- **Oday — YouTube Playlists Web App** — curate multi-playlist learning tracks.  
-  [Read →]({{ '/projects/oday-playlists/' | relative_url }})
+## Active
+{% for project in site.data.projects.active %}
+- **[{{ project.title }}]({{ '/projects/' | append: project.slug | append: '/' | relative_url }})** — {{ project.description }}
+  
+  Tags:
+  {% for tag in project.tags %}[{{ tag }}]({{ '/tags/' | append: tag | relative_url }}){% unless forloop.last %}, {% endunless %}{% endfor %}
+  {% if project.sub_projects %}
+  - Sub-projects:
+    {% for sub in project.sub_projects %}
+    - [{{ sub.title }}]({{ '/projects/' | append: sub.slug | append: '/' | relative_url }})
+    {% endfor %}
+  {% endif %}
+{% endfor %}
+
+## Completed
+{% for project in site.data.projects.completed %}
+- **[{{ project.title }}]({{ '/projects/' | append: project.slug | append: '/' | relative_url }})** — {{ project.description }}
+  
+  Tags:
+  {% for tag in project.tags %}[{{ tag }}]({{ '/tags/' | append: tag | relative_url }}){% unless forloop.last %}, {% endunless %}{% endfor %}
+{% endfor %}

--- a/projects/oday-playlists/index.md
+++ b/projects/oday-playlists/index.md
@@ -1,6 +1,7 @@
 ---
 title: Oday — YouTube Playlists Web App
 layout: default
+tags: [web, angular]
 ---
 
 # Oday — YouTube Playlists Web App
@@ -34,5 +35,7 @@ function markComplete(videoId: string) {
 * **Learning continuity:** users resume exactly where they left off
 * **Simplicity:** zero-build static site keeps maintenance low
 * **Shareability:** easy to send curated tracks to friends
+
+Tags: {% for tag in page.tags %}[{{ tag }}]({{ '/tags/' | append: tag | relative_url }}){% unless forloop.last %}, {% endunless %}{% endfor %}
 
 **Links:** [Back to Projects]({{ '/projects/' | relative_url }}) • [Source or Demo (if public)](https://example.com)

--- a/projects/ue-advanced-dialogue/index.md
+++ b/projects/ue-advanced-dialogue/index.md
@@ -1,7 +1,10 @@
 ---
 title: Advanced Dialogue System (UE)
 layout: default
+tags: [unreal, cpp]
 ---
+
+[← Unreal Gameplay Systems]({{ '/projects/ue-gameplay-systems/' | relative_url }})
 
 # Advanced Dialogue System (UE5)
 
@@ -33,5 +36,7 @@ bool UDialogueRuntime::EvaluateCondition(const FDialogueCondition& Cond) const {
 * **Authoring speed:** designers created branches 2–3× faster
 * **Fewer bugs:** validation prevented common runtime nulls/misrefs
 * **Reusability:** same system powers NPC barks, tutorials, and quests
+
+Tags: {% for tag in page.tags %}[{{ tag }}]({{ '/tags/' | append: tag | relative_url }}){% unless forloop.last %}, {% endunless %}{% endfor %}
 
 **Links:** [Back to Projects]({{ '/projects/' | relative_url }}) • [Source or Demo (if public)](https://example.com)

--- a/projects/ue-gameplay-systems/index.md
+++ b/projects/ue-gameplay-systems/index.md
@@ -1,0 +1,15 @@
+---
+title: Unreal Gameplay Systems
+layout: default
+tags: [unreal, cpp]
+---
+
+# Unreal Gameplay Systems
+
+Suite of reusable UE5 modules focused on dialogue, quests, and AI behavior.
+
+## Sub-projects
+- [Advanced Dialogue System]({{ '/projects/ue-advanced-dialogue/' | relative_url }})
+- [Questing & Behavior Systems]({{ '/projects/ue-quest-behavior/' | relative_url }})
+
+Tags: {% for tag in page.tags %}[{{ tag }}]({{ '/tags/' | append: tag | relative_url }}){% unless forloop.last %}, {% endunless %}{% endfor %}

--- a/projects/ue-quest-behavior/index.md
+++ b/projects/ue-quest-behavior/index.md
@@ -1,7 +1,10 @@
 ---
 title: Questing & Behavior Systems (UE)
 layout: default
+tags: [unreal, cpp]
 ---
+
+[← Unreal Gameplay Systems]({{ '/projects/ue-gameplay-systems/' | relative_url }})
 
 # Questing & Behavior Systems (UE5)
 
@@ -32,5 +35,7 @@ void UBTTask_TickQuest::ExecuteTask(UBehaviorTreeComponent& OwnerComp) {
 * **Design velocity:** new quests built without engineering support
 * **Consistency:** shared tasks reduced duplicated logic
 * **Player engagement:** tighter AI integration improved quest responsiveness
+
+Tags: {% for tag in page.tags %}[{{ tag }}]({{ '/tags/' | append: tag | relative_url }}){% unless forloop.last %}, {% endunless %}{% endfor %}
 
 **Links:** [Back to Projects]({{ '/projects/' | relative_url }}) • [Source or Demo (if public)](https://example.com)

--- a/resume/index.md
+++ b/resume/index.md
@@ -1,5 +1,5 @@
 ---
-title: Resume — Your Name
+title: Resume — {{ site.data.resume.name }}
 layout: default
 ---
 
@@ -8,26 +8,30 @@ layout: default
 [Download PDF]({{ '/resume/resume.pdf' | relative_url }})
 
 ## Summary
-Systems-oriented UE & web developer focused on tools that accelerate designers and keep code maintainable.
+{{ site.data.resume.summary }}
 
 ## Skills
-- **Languages:** C++, TypeScript/JavaScript
-- **Engines/Frameworks:** Unreal Engine 5, HTML5/CSS
-- **Tools:** Git, GitHub Actions, (add more)
+{% for group in site.data.resume.skills %}
+- **{{ group.title }}:** {{ group.skills | join: ', ' }}
+{% endfor %}
 
-## Experience
-**Role — Company (YYYY–YYYY)**  
-- Impact bullet 1 (action → result).  
-- Impact bullet 2 (metric if possible).
-
-**Earlier Role — Company (YYYY–YYYY)**  
-- Impact bullet 1.  
-- Impact bullet 2.
+## Work Experience
+{% for job in site.data.resume.workExperience %}
+**{{ job.position }} — {{ job.company }} ({{ job.startYear | slice: 0,4 }}–{{ job.endYear }})**
+{{ job.description }}
+{% assign bullets = job.keyAchievements | split: '\\n' %}
+{% for line in bullets %}
+- {{ line }}
+{% endfor %}
+{% endfor %}
 
 ## Education
-Degree — School
+{% for edu in site.data.resume.education %}
+**{{ edu.degree }} — {{ edu.school }}**
+{% endfor %}
 
 ## Links
-- GitHub — yourhandle  
-- LinkedIn — /in/yourhandle  
-- Email — yourname@example.com
+{% for profile in site.data.resume.socialMedia %}
+- {{ profile.socialMedia }} — {{ profile.link }}
+{% endfor %}
+- Email — {{ site.data.resume.email }}

--- a/tags/angular.md
+++ b/tags/angular.md
@@ -1,0 +1,5 @@
+---
+title: "Tag: angular"
+layout: tag
+tag: angular
+---

--- a/tags/cpp.md
+++ b/tags/cpp.md
@@ -1,0 +1,5 @@
+---
+title: "Tag: cpp"
+layout: tag
+tag: cpp
+---

--- a/tags/index.md
+++ b/tags/index.md
@@ -1,0 +1,11 @@
+---
+title: Tags
+layout: default
+---
+
+# Tags
+
+- [unreal]({{ '/tags/unreal/' | relative_url }})
+- [cpp]({{ '/tags/cpp/' | relative_url }})
+- [web]({{ '/tags/web/' | relative_url }})
+- [angular]({{ '/tags/angular/' | relative_url }})

--- a/tags/unreal.md
+++ b/tags/unreal.md
@@ -1,0 +1,5 @@
+---
+title: "Tag: unreal"
+layout: tag
+tag: unreal
+---

--- a/tags/web.md
+++ b/tags/web.md
@@ -1,0 +1,5 @@
+---
+title: "Tag: web"
+layout: tag
+tag: web
+---


### PR DESCRIPTION
## Summary
- source homepage and resume content from a JSON resume
- add project data file for active/completed items with sub-projects and tags
- introduce tag pages and UE systems parent page for nested navigation

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68bb22da8b7c8329b825ca6f25d484c8