### PR TITLE
Fix tag template to display posts and projects

### DIFF
--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -1,20 +1,55 @@
 ---
-layout: default
+layout: page
 ---
 
-<h1>Tag: {{ page.tag }}</h1>
-<ul>
-{% assign all = site.data.projects.active | concat: site.data.projects.completed %}
-{% for project in all %}
-  {% if project.tags contains page.tag %}
-    <li><a href="{{ '/projects/' | append: project.slug | append: '/' | relative_url }}">{{ project.title }}</a></li>
-  {% endif %}
-  {% if project.sub_projects %}
-    {% for sub in project.sub_projects %}
-      {% if sub.tags contains page.tag %}
-        <li><a href="{{ '/projects/' | append: sub.slug | append: '/' | relative_url }}">{{ sub.title }}</a></li>
-      {% endif %}
+{% include lang.html %}
+
+<div id="page-tag">
+  {% assign tag_name = page.tag | default: page.title %}
+  <h1 class="ps-lg-2">
+    <i class="fa fa-tag fa-fw text-muted"></i>
+    {{ tag_name }}
+    {% if page.posts %}
+      <span class="lead text-muted ps-2">{{ page.posts | size }}</span>
+    {% endif %}
+  </h1>
+
+  {% if page.posts %}
+  <ul class="content ps-0">
+    {% for post in page.posts %}
+      <li class="d-flex justify-content-between px-md-3">
+        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        <span class="dash flex-grow-1"></span>
+        {% include datetime.html date=post.date class='text-muted small text-nowrap' lang=lang %}
+      </li>
     {% endfor %}
+  </ul>
   {% endif %}
-{% endfor %}
-</ul>
+
+  {% assign tag_name = tag_name | downcase %}
+  {% assign all = site.data.projects.active | concat: site.data.projects.completed %}
+  {% assign projects = '' | split: '' %}
+  {% for project in all %}
+    {% assign project_tags = project.tags | map: 'downcase' %}
+    {% if project_tags contains tag_name %}
+      {% assign projects = projects | push: project %}
+    {% endif %}
+    {% if project.sub_projects %}
+      {% for sub in project.sub_projects %}
+        {% assign sub_tags = sub.tags | map: 'downcase' %}
+        {% if sub_tags contains tag_name %}
+          {% assign projects = projects | push: sub %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  {% endfor %}
+
+  {% if projects.size > 0 %}
+  <h2 class="ps-lg-2 mt-4">Projects</h2>
+  <ul class="content ps-0">
+    {% for proj in projects %}
+      <li><a href="{{ '/projects/' | append: proj.slug | append: '/' | relative_url }}">{{ proj.title }}</a></li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary
- Restore tag layout to list blog posts for each tag
- Add project references below posts so tags link to related projects too

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68bb6951fe308329aff1f66254d6cd63