### PR TITLE
refactor: enrich blog tags with resume skills

### DIFF
--- a/_posts/2025-04-05-cityrpg-overview.md
+++ b/_posts/2025-04-05-cityrpg-overview.md
@@ -3,7 +3,15 @@ layout: post
 title: "CityRPG Overview"
 date: 2025-04-05 00:00:00 +0000
 categories: [CityRPG]
-tags: [Angular, UE5, CityRPG, Gameplay]
+tags:
+  - CityRPG
+  - Angular
+  - UE5
+  - C++
+  - TypeScript
+  - RxJS
+  - NgRx
+  - Firebase
 ---
 
 *CityRPG* is an ambitious mod for **Brickadia** that transforms its open-ended building sandbox into an active, living city. It pairs a robust back-end service with an Angular-based UI to keep the game scalable, responsive, and ready for future server expansion.

--- a/_posts/2025-04-05-odeya-overview.md
+++ b/_posts/2025-04-05-odeya-overview.md
@@ -3,7 +3,15 @@ layout: post
 title: 'odeya Overview'
 date: 2025-03-15 00:00:00 +0000
 categories: [ODEYA]
-tags: [Angular, SSR, Playlists, SEO]
+tags:
+  - ODEYA
+  - Angular
+  - SSR
+  - RxJS
+  - NgRx
+  - TypeScript
+  - Firebase
+  - SEO
 ---
 
 _ODEYA_ is a focused utility for heavy YouTube users: create **channel collections** (e.g., Cruise News, Gaming, Tech) and let ODEYA automatically **populate a single playlist** every time any channel in that collection publishes a new video. It started as a personal tool to eliminate manual playlist maintenance—and it stuck.

--- a/_posts/2025-04-05-trapped-overview.md
+++ b/_posts/2025-04-05-trapped-overview.md
@@ -3,7 +3,24 @@ layout: post
 title: "Unreal Engine Gameplay Overview"
 date: 2024-03-05 00:00:00 +0000
 categories: [Trapped (UE5 Game)]
-tags: [Unreal Engine, Gameplay]
+tags:
+  - Trapped
+  - Unreal Engine 5
+  - C++
+  - UMG
+  - HUD
+  - Dialogue System
+  - Quest System
+  - AI Movement
+  - Spawning
+  - Redux-style State
+  - Data-Driven Design
+  - Tooling
+  - Debugging
+  - Profiling
+  - Optimization
+  - LLM Integration
+  - Git
 ---
 
 This overview highlights a gameplay system prototype I built in Unreal Engine 5, inspired by projects listed on my resume.

--- a/_posts/2025-04-05-unified-process-overview.md
+++ b/_posts/2025-04-05-unified-process-overview.md
@@ -3,7 +3,36 @@ layout: post
 title: 'Unified Process Overview'
 date: 2025-04-05 00:00:00 +0000
 categories: [Unified Process]
-tags: [Angular, Unified Process]
+tags:
+  - Unified Process
+  - Angular
+  - TypeScript
+  - RxJS
+  - NgRx
+  - Java
+  - "C#"
+  - Python
+  - Kafka
+  - CDC
+  - Data Medallion Layers
+  - Kubernetes
+  - Ansible
+  - Azure DevOps
+  - GitHub Actions
+  - GitLab Runners
+  - GCP
+  - Firebase
+  - Grafana
+  - Prometheus
+  - Loki
+  - Tempo
+  - Keycloak
+  - Kerberos
+  - PKI
+  - TLS
+  - "RHEL 9"
+  - Feature Flags
+  - DORA Metrics
 ---
 
 The Expeditors Software Unified Process is a software solution that integrates various business processes and workflows into a cohesive system. It aims to streamline operations, improve collaboration, and enhance overall efficiency within the organization.

--- a/_posts/2025-04-05-workflow-overview.md
+++ b/_posts/2025-04-05-workflow-overview.md
@@ -3,7 +3,37 @@ layout: post
 title: 'Workflow Overview'
 date: 2025-04-05 00:00:00 +0000
 categories: [Unified Process]
-tags: [Angular, Unified Process]
+tags:
+  - Workflow
+  - Unified Process
+  - Angular
+  - TypeScript
+  - RxJS
+  - NgRx
+  - Java
+  - "C#"
+  - Python
+  - Kafka
+  - CDC
+  - Data Medallion Layers
+  - Kubernetes
+  - Ansible
+  - Azure DevOps
+  - GitHub Actions
+  - GitLab Runners
+  - GCP
+  - Firebase
+  - Grafana
+  - Prometheus
+  - Loki
+  - Tempo
+  - Keycloak
+  - Kerberos
+  - PKI
+  - TLS
+  - "RHEL 9"
+  - Feature Flags
+  - DORA Metrics
 ---
 
 The Expeditors Workflow application is a comprehensive solution designed to streamline and automate business processes within an organization. It integrates various functionalities to enhance productivity, improve collaboration, and ensure efficient task management across teams.


### PR DESCRIPTION
## Summary
- replace generic blog tags with application names and resume-based skills
- expand each post with relevant Angular and Unreal Engine capabilities

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68bb6c8726748329a014de350bdaf71c