### PR TITLE
Replace post image placeholders with SVG links

### DIFF
--- a/_posts/2025-04-05-cityrpg-business-community.md
+++ b/_posts/2025-04-05-cityrpg-business-community.md
@@ -17,8 +17,7 @@ tags:
 
 This guide dives into how businesses, shops, and the wider community ecosystem work together in CityRPG. Use it to start a company, sell goods, and understand how city policies and the live economy affect your day‑to‑day play.
 
-> Add a header image
-> `![Storefronts and players trading](path-or-url-to-image)`
+![Storefronts and players trading](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -40,7 +39,7 @@ This guide dives into how businesses, shops, and the wider community ecosystem w
 - **Set roles**: Decide who handles sourcing, crafting, pricing, and customer service.
 - **Use in‑game menus**: Where available, use Town Hall/Business desks or in‑game actions to manage membership and permissions.
 
-> `![Lot purchase UI or business desk](image-url)`
+![Lot purchase UI or business desk](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -52,7 +51,7 @@ This guide dives into how businesses, shops, and the wider community ecosystem w
 - **Offline receipts**: Sellers automatically receive inbox messages confirming sales, so shopkeepers can run stores even while offline.
 - **Pricing**: Set fair prices, consider economy swings, and watch stock levels to avoid outages.
 
-> `![Shop UI or menu board](image-url)`
+![Shop UI or menu board](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -63,7 +62,7 @@ This guide dives into how businesses, shops, and the wider community ecosystem w
 - **Tiering**: Higher skill and recipe unlocks improve efficiency and margins over time.
 - **Division of labor**: Assign members to gathering, crafting, cooking, sales, and restocking for a steady loop.
 
-> `![Crafting bench and storage](image-url)`
+![Crafting bench and storage](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -74,7 +73,7 @@ This guide dives into how businesses, shops, and the wider community ecosystem w
 - **Business accounting**: Keep a ledger of materials costs, sale prices, and net profit. Use bank deposits/withdrawals to separate business from personal spending.
 - **Taxes & policy**: City leadership can adjust tax rates and policies that influence business costs and margins.
 
-> `![Bank zone and account UI](image-url)`
+![Bank zone and account UI](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -85,7 +84,7 @@ This guide dives into how businesses, shops, and the wider community ecosystem w
 - **Live economy**: The city’s economy percentage drifts over time and can be affected by events. Some rewards scale with this value.
 - **Donations**: Players can donate to buoy the economy. Use `/donate <amount>` to contribute; a portion of the donation raises the economy within configured caps.
 
-> `![Election posters or voting booth](image-url)`
+![Election posters or voting booth](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -96,7 +95,7 @@ This guide dives into how businesses, shops, and the wider community ecosystem w
 - **Law & order**: Demerits raise wanted level; officers earn bounties for lawful apprehensions. Clear your record at Town Hall with `/clearrecord` (fee applies).
 - **Events & security**: Bank heists require certain conditions (e.g., officers online). Criminal activity impacts the economy and risk/reward for everyone.
 
-> `![Town Hall, bank, and police station collage](image-url)`
+![Town Hall, bank, and police station collage](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -117,7 +116,7 @@ This guide dives into how businesses, shops, and the wider community ecosystem w
 - Messaging: `/msg <player> <text>`, `/inbox [page]` for offline receipts and mail.
 - Records: `/clearrecord` at Town Hall (fee) to wipe demerits.
 
-> `![Command overlay or help menu](image-url)`
+![Command overlay or help menu](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 

--- a/_posts/2025-04-05-cityrpg-jobs.md
+++ b/_posts/2025-04-05-cityrpg-jobs.md
@@ -14,8 +14,7 @@ tags:
 
 This guide explains how progression works in CityRPG through two pillars: skills and jobs. Use it to pick a role, earn pay, and level up by doing the activities you enjoy.
 
-> Add a header image for flavor  
-> `![Job board or city scene](path-or-url-to-image)`
+![Job board or city scene](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -77,7 +76,7 @@ CityRPG uses a light, RuneScape‑inspired system: do the activity to gain the r
 - Records: Clear your criminal record inside the Town Hall (`/clearrecord`, fee applies).
 - Purchases: Confirm store/weapon/food buys with `/yes` after a prompt.
 
-> `![Police, shop, or crafting UI screenshots](path-or-url-to-image)`
+![Police, shop, or crafting UI screenshots](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 

--- a/_posts/2025-04-05-cityrpg-overview.md
+++ b/_posts/2025-04-05-cityrpg-overview.md
@@ -16,10 +16,7 @@ tags:
 
 *CityRPG* is an ambitious mod for **Brickadia** that transforms its open-ended building sandbox into an active, living city. It pairs a robust back-end service with an Angular-based UI to keep the game scalable, responsive, and ready for future server expansion.
 
-> **Add a banner image here**
->
-> Example (Markdown):  
-> `![City skyline or logo](path-or-url-to-banner-image)`
+![City skyline or logo](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -29,8 +26,7 @@ CityRPG is both:
 - **A Web-Based UI** – the UI is built in Angular and interacts with a service-based backend (e.g., Firebase), offloading significant logic to the cloud for scalability.
 - **A Website** – enabling players to manage accounts, track stats, and eventually connect across multiple servers/regions.
 
-> **Insert gameplay screenshots or concept art as desired**  
-> `![Player exploring the city](image-url)`
+![Player exploring the city](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -45,7 +41,7 @@ CityRPG is both:
   - Purchase lots, build storefronts, or craft unique items to sell.
   - Set taxes as the city evolves (tied to the election system below).
 
-> `![Lot management UI](image-url)`
+![Lot management UI](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ### Skills & Jobs
 - **RuneScape-Inspired Skill Progression**  
@@ -57,7 +53,7 @@ CityRPG is both:
   - **Law Enforcement** – Official role with structured progression and XP.  
   - **Criminal Route** – Not an official “job,” but a set of activities (e.g., weapon crafting, bank heists, laptop hacking) for players who prefer to live on the edge.
 
-> `![Skill menu screenshot](image-url)`
+![Skill menu screenshot](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ### Quests & Activities
 - Branching quests and task systems that provide currency, XP, or rare items.
@@ -74,14 +70,14 @@ CityRPG is both:
   - Craft meals, set restaurant pricing, and manage stock.
   - Profits feed back into personal or business finances.
 
-> `![Crafting bench screenshot](image-url)`
+![Crafting bench screenshot](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ### Political System
 - **Elections & Taxes**  
   - Run for mayor and influence city policy.
   - Set taxes, manage city finances, and face potential impeachment if citizens are unhappy.
 
-> `![Voting booth or election posters](image-url)`
+![Voting booth or election posters](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ### Voyages & Sea Exploration
 - Plan a voyage, recruit crew members, and sail out from the city.
@@ -89,7 +85,7 @@ CityRPG is both:
   - NPC encounters.
   - Cooperative combat and loot return loops similar to *Sea of Thieves*.
 
-> `![Players on a ship or sea horizon](image-url)`
+![Players on a ship or sea horizon](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -105,7 +101,7 @@ CityRPG is both:
 - **Scalability**  
   - If one city runs out of lots, new servers/regions can spin up with shared accounts and inventory, helping reduce latency worldwide.
 
-> `![UI mockup or code snippet image](image-url)`
+![UI mockup or code snippet image](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -115,13 +111,13 @@ CityRPG is both:
 3. **Choose Your Path** – start a job, craft items, or delve into criminal activities.  
 4. **Climb the Ranks** in your chosen skills to unlock advanced features.
 
-> `![Player showcase or feature highlight image](image-url)`
+![Player showcase or feature highlight image](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
 ## Tips for Adding Images
-- **Markdown**: `![Alt text](image-url)`
-- **HTML**: `<img src="image-url" alt="Description" width="600"/>`
+- **Markdown**: `![Alt text](https://placehold.co/600x400?text=Placeholder&format=svg)`
+- **HTML**: `<img src="https://placehold.co/600x400?text=Placeholder&format=svg" alt="Description" width="600"/>`
 - Use descriptive file names and alt text for accessibility.
 - Maintain consistent sizing and styling for a clean visual flow.
 
@@ -130,7 +126,7 @@ CityRPG is both:
 ## Final Thoughts
 CityRPG expands Brickadia into a full-fledged RPG experience, blending **economy**, **job roles**, **player politics**, and **cooperative adventures**. Thanks to its service-oriented architecture and Angular UI, the mod is built for the long term—ready to scale and evolve with its community.
 
-> `![Closing concept art or logo](image-url)`
+![Closing concept art or logo](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 Feel free to adjust the text, add/remove sections, and insert screenshots or concept art wherever placeholders appear to create a polished overview that captures the depth and excitement of CityRPG.
 

--- a/_posts/2025-04-05-cityrpg-political-system.md
+++ b/_posts/2025-04-05-cityrpg-political-system.md
@@ -14,8 +14,7 @@ tags:
 
 CityRPG features an in-game political layer where players campaign for office, set city policy, and keep the economy running. This post explains how elections work, what powers leaders hold, and how citizens can keep their government in check.
 
-> Add a header image
-> `![Town hall and campaign posters](path-or-url-to-image)`
+![Town hall and campaign posters](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -26,7 +25,7 @@ CityRPG features an in-game political layer where players campaign for office, s
 - **Voting**: Once the election period opens, players cast votes via UI or `/election vote <name>`. Highest votes wins.
 - **Term**: The winner becomes city leader (mayor) until impeached, removed, or a new election is held.
 
-> `![Voting booth or ballot UI](image-url)`
+![Voting booth or ballot UI](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -37,7 +36,7 @@ CityRPG features an in-game political layer where players campaign for office, s
 - **Post Contracts & Policies**: Leaders may post city contracts (`/citycontractpost`) or modify policies that influence gameplay loops.
 - **Economy Modifier**: Leaders can influence the live economy percentage via donations or certain policies, shifting payouts up or down.
 
-> `![Mayor office and policy screen](image-url)`
+![Mayor office and policy screen](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -55,7 +54,7 @@ CityRPG features an in-game political layer where players campaign for office, s
 - **Auto-Removal**: Leaders may also be removed for inactivity or poor approval depending on server rules.
 - **Checks & Balances**: Regular elections and open commands ensure no one holds power indefinitely.
 
-> `![Citizens protesting at town hall](image-url)`
+![Citizens protesting at town hall](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 

--- a/_posts/2025-04-05-cityrpg-quests-activities.md
+++ b/_posts/2025-04-05-cityrpg-quests-activities.md
@@ -14,8 +14,7 @@ tags:
 
 CityRPG uses quests and quick activities to keep players busy whether they want story, side hustles, or high‑risk crimes.
 
-> Add a header image
-> `![Exploring the city](path-or-url-to-image)`
+![Exploring the city](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -25,7 +24,7 @@ CityRPG uses quests and quick activities to keep players busy whether they want 
 - **Objective tracking**: Each quest has objectives that mark themselves complete when you do the required action or gather items.
 - **Repeatable content**: Some quests can restart after completion for steady cash or XP.
 
-> `![Quest dialogue or objective list](image-url)`
+![Quest dialogue or objective list](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -43,7 +42,7 @@ CityRPG uses quests and quick activities to keep players busy whether they want 
 - **Hacking puzzle**: A timed typing sequence determines if the vault opens. Wrong answers or leaving early fails the run.
 - **Dirty money & crime XP**: Escaping with the loot grants cash and XP while draining the city treasury.
 
-> `![Heist console or escape scene](image-url)`
+![Heist console or escape scene](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -69,7 +68,7 @@ CityRPG uses quests and quick activities to keep players busy whether they want 
 - Bring friends to watch your back during heists or escort deliveries.
 - Check the quest log often—new tasks and repeatables appear as the city evolves.
 
-> `![Party completing a quest](image-url)`
+![Party completing a quest](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 

--- a/_posts/2025-04-05-cityrpg-technical-backbone.md
+++ b/_posts/2025-04-05-cityrpg-technical-backbone.md
@@ -17,8 +17,7 @@ tags:
 
 CityRPG succeeds because its core systems are split across the game client, an Angular web interface, and a service-driven backend. This post explains how those pieces fit together and why the mod can scale beyond a single Brickadia server.
 
-> Add a header image showing the architecture
-> `![High-level architecture diagram](path-or-url-to-image)`
+![High-level architecture diagram](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -28,7 +27,7 @@ CityRPG succeeds because its core systems are split across the game client, an A
 - **Reactive pipeline** – RxJS streams process chat commands, inventory changes, and world events in real time.
 - **Native hooks** – When low-level control is required, C++/UE5 hooks surface data to the plugin for higher-level handling.
 
-> `![Omegga console or plugin code](image-url)`
+![Omegga console or plugin code](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ## Angular Web UI
 
@@ -36,7 +35,7 @@ CityRPG succeeds because its core systems are split across the game client, an A
 - **State management** – NgRx keeps UI state predictable; actions from the plugin or backend flow into a single store.
 - **Offline-ready** – The UI caches essential data so players retain menus even during transient network hiccups.
 
-> `![Angular-based menu screenshot](image-url)`
+![Angular-based menu screenshot](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ## Cloud Services
 
@@ -44,7 +43,7 @@ CityRPG succeeds because its core systems are split across the game client, an A
 - **Job queues & functions** – Long-running tasks (heist resolution, voyage logic) execute in functions to avoid blocking the game loop.
 - **Analytics** – Centralized logs and metrics feed future balancing and abuse detection.
 
-> `![Firebase dashboard or function code](image-url)`
+![Firebase dashboard or function code](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ## Scaling Across Servers
 
@@ -52,7 +51,7 @@ CityRPG succeeds because its core systems are split across the game client, an A
 - **Service boundaries** – Each server only owns session state; all persistent data is remote, allowing new shards to spin up quickly.
 - **Future extensions** – Additional microservices (matchmaking, trading post) can plug in without touching the core plugin.
 
-> `![Multiple servers connected to a single backend](image-url)`
+![Multiple servers connected to a single backend](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -62,7 +61,7 @@ CityRPG succeeds because its core systems are split across the game client, an A
 - **Testing & CI** – Scripts validate gameplay logic with ts-node tests; GitHub Actions can run them on pull requests.
 - **Config-driven** – Environments and feature flags load from Firebase, letting admins tweak balance without redeploying.
 
-> `![CI pipeline or code snippet](image-url)`
+![CI pipeline or code snippet](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -70,5 +69,5 @@ CityRPG succeeds because its core systems are split across the game client, an A
 
 CityRPG’s technical backbone separates presentation, game logic, and persistence so the mod stays maintainable and ready for growth. The combination of an Angular UI, an Omegga plugin, and Firebase services turns Brickadia into a living world that can span many servers.
 
-> `![Closing image or logo](image-url)`
+![Closing image or logo](https://placehold.co/600x400?text=Placeholder&format=svg)
 

--- a/_posts/2025-04-05-cityrpg-voyages.md
+++ b/_posts/2025-04-05-cityrpg-voyages.md
@@ -13,8 +13,7 @@ tags:
 
 Voyages turn the open sea into a cooperative resource loop. Gather a crew, claim a ship, and sail to remote islands packed with stone and lumber. This post explains how voyages work, from planning to payouts.
 
-> Add a header image here
-> `![Ship setting sail](path-or-url-to-image)`
+![Ship setting sail](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -27,7 +26,7 @@ Voyages turn the open sea into a cooperative resource loop. Gather a crew, claim
 - Update compensation or label later with `/voyage set-comp ...` and `/voyage set-label ...`.
 - Kick misbehaving members with `/voyage kick <playerNameOrId>`.
 
-> `![Voyage creation UI](image-url)`
+![Voyage creation UI](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -47,7 +46,7 @@ Voyages turn the open sea into a cooperative resource loop. Gather a crew, claim
 - Carry up to 10 lumber and 10 stone at a time. Use `storeonship` bricks to stash resources in the ship's hold.
 - Pay-per-minute voyages automatically pay crew over time. Crew-cut voyages distribute resources based on time spent when the captain ends the trip.
 
-> `![Crew harvesting resources](image-url)`
+![Crew harvesting resources](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -75,7 +74,7 @@ Voyages turn the open sea into a cooperative resource loop. Gather a crew, claim
 /voyage set-label <label>
 ```
 
-> `![Command overlay screenshot](image-url)`
+![Command overlay screenshot](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 

--- a/_posts/2025-04-05-odeya-overview.md
+++ b/_posts/2025-04-05-odeya-overview.md
@@ -16,10 +16,7 @@ tags:
 
 _ODEYA_ is a focused utility for heavy YouTube users: create **channel collections** (e.g., Cruise News, Gaming, Tech) and let ODEYA automatically **populate a single playlist** every time any channel in that collection publishes a new video. It started as a personal tool to eliminate manual playlist maintenance—and it stuck.
 
-> **Add a banner image here**
->
-> Example (Markdown):  
-> `![ODEYA banner or logo](path-or-url-to-banner-image)`
+![ODEYA banner or logo](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -31,8 +28,7 @@ ODEYA is:
 -   **A Playlist Engine** — many‑to‑one mapping from multiple channels to one rolling playlist.
 -   **A Sharing Layer** — server‑side rendering (SSR) makes shared playlists discoverable by search engines.
 
-> **Insert UI screenshots or short clips**  
-> `![Creating a channel collection](image-url)`
+![Creating a channel collection](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -53,7 +49,7 @@ ODEYA is:
 -   **Server‑Side Rendering** ensures shared playlist pages are crawlable and indexable.
 -   Friends can follow public playlists; search engines can surface your curated collections.
 
-> `![Shared playlist page with preview cards](image-url)`
+![Shared playlist page with preview cards](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ### Practical Curation
 
@@ -68,7 +64,7 @@ ODEYA is:
 -   **Gaming & Tech Roundups:** track daily uploads across many creators without hopping between subscriptions.
 -   **Education Playlists:** bundle a set of instructors/channels into a rolling curriculum.
 
-> `![Topic collection setup: Cruise News](image-url)`
+![Topic collection setup: Cruise News](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -83,7 +79,7 @@ ODEYA is:
 -   **Performance & Stability**  
     Built to be lightweight for personal use, with room to evolve if broader adoption happens later.
 
-> `![Simplified data flow diagram](image-url)`
+![Simplified data flow diagram](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -94,16 +90,16 @@ ODEYA is:
 3. **Choose a Playlist**: set the destination playlist (or create a new one).
 4. **Share**: send the public link to friends or post it—SSR makes it discoverable.
 
-> `![Sharing a playlist link](image-url)`
+![Sharing a playlist link](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
 ## Tips for Adding Images
 
--   **Markdown**: `![Alt text](image-url)`
--   **HTML**: `<img src="image-url" alt="Description" width="600" />`
--   Use specific alt text and descriptive filenames for accessibility and better previews.
--   Keep dimensions consistent for a clean visual rhythm.
+- **Markdown**: `![Alt text](https://placehold.co/600x400?text=Placeholder&format=svg)`
+- **HTML**: `<img src="https://placehold.co/600x400?text=Placeholder&format=svg" alt="Description" width="600" />`
+- Use specific alt text and descriptive filenames for accessibility and better previews.
+- Keep dimensions consistent for a clean visual rhythm.
 
 ---
 
@@ -111,4 +107,4 @@ ODEYA is:
 
 ODEYA removes the friction of staying up to date on YouTube by **automating curation** and **making playlists easy to share and find**. It began as a personal project, but the approach scales naturally: define your interests once, and let fresh content flow where you want it—without the busywork.
 
-> `![Closing logo or UI detail](image-url)`
+![Closing logo or UI detail](https://placehold.co/600x400?text=Placeholder&format=svg)

--- a/_posts/2025-04-05-unified-process-overview.md
+++ b/_posts/2025-04-05-unified-process-overview.md
@@ -23,10 +23,7 @@ tags:
 
 _Unified Process_ is a step‑centric platform for logistics workflows. Instead of relying solely on event streams, it models each business process as an explicit sequence of **steps**, **transitions**, and **guards**—making state changes observable, testable, and easier to recover when things go wrong. The front end is built with Angular (Signals + NgRx), with deep instrumentation across the stack.
 
-> **Add a banner image here**
->
-> Example (Markdown):  
-> `![Process orchestration banner](path-or-url-to-banner-image)`
+![Process orchestration banner](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -38,8 +35,7 @@ Unified Process is:
 -   **A Front‑End for Operators** — Angular UI surfaces the current step, blockers, SLAs, and remediation actions.
 -   **An Observability‑First System** — traces, metrics, and logs tie every step to its upstream/downstream services.
 
-> **Insert UI screenshots or diagrams**  
-> `![Operator console showing step timeline](image-url)`
+![Operator console showing step timeline](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 ---
 
@@ -62,7 +58,7 @@ Event buses are great at decoupling producers and consumers, but complex operati
 -   **Guards**: Boolean checks (data present, validations complete, external ACK received).
 -   **Effects**: Side‑effects on transition (emit command, write record, notify, update index).
 
-> `![State machine sketch: Received → Validated → Booked → Dispatched → Delivered](image-url)`
+![State machine sketch: Received → Validated → Booked → Dispatched → Delivered](https://placehold.co/600x400?text=Placeholder&format=svg)
 
 Example (illustrative YAML‑style):
 


### PR DESCRIPTION
## Summary
- swap template image references across posts for actual SVG placeholders
- document example usage with placeholder links

## Testing
- `bundle install` *(fails: gem install process incomplete)*
- `bundle exec jekyll build` *(fails: jekyll executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bda05897348329bf7b030b52a00438